### PR TITLE
Cache Composer's cache

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,11 +4,34 @@ on: [push]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4']
+
+    name: PHP ${{ matrix.php-versions }}
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Setup PHP ${{ matrix.php-versions }}
+      uses: shivammathur/setup-php@v1
+      with:
+        php-version: ${{ matrix.php-versions }}
+
+    - name: Setup Problem Matchers for PHPUnit
+      run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - uses: actions/cache@v1
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        restore-keys: ${{ runner.os }}-composer-
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -21,3 +44,7 @@ jobs:
 
     - name: Run tests
       run: composer run-script phpunit
+
+    # Ensure the next test run fetches the latest test ruleset.
+    - name: Remove httpwg/structured-header-tests from composer cache
+      run: rm -rf $(composer config cache-files-dir)/httpwg


### PR DESCRIPTION
- Setup test matrix to test on multiple PHP versions
- Cache composer's cache files between runs
- Keep `httpwg/structured-header-tests` out of the cache so that the latest rules are always checked.

Cache entries are immutable (only created on first run after composer.json is changed), but are evicted if not accessed for 7 days, so the cache shouldn't get too out-of-date to be useful.