### PR TITLE
Stop skipping tests with duplicate keys

### DIFF
--- a/tests/RulesetDictionaryTest.php
+++ b/tests/RulesetDictionaryTest.php
@@ -5,12 +5,4 @@ namespace gapple\Tests\StructuredHeaders;
 class RulesetDictionaryTest extends RulesetTest
 {
     protected $ruleset = 'dictionary';
-
-    protected $skipParsingRules = [
-        'duplicate key dictionary' => 'Duplicate dictionary keys should overwrite previous value.',
-    ];
-
-    protected $skipSerializingRules = [
-        'duplicate key dictionary' => 'Duplicate dictionary keys should overwrite previous value.',
-    ];
 }

--- a/tests/RulesetKeyGeneratedTest.php
+++ b/tests/RulesetKeyGeneratedTest.php
@@ -5,14 +5,4 @@ namespace gapple\Tests\StructuredHeaders;
 class RulesetKeyGeneratedTest extends RulesetTest
 {
     protected $ruleset = 'key-generated';
-
-    protected $skipParsingRules = [
-        '0x2c in dictionary key' => 'comma is valid character in dictionary',
-        '0x3b in parameterised list key' => 'semicolon is valid character in parameter list',
-    ];
-
-    protected $skipSerializingRules = [
-        '0x2c in dictionary key' => 'comma is valid character in dictionary',
-        '0x3b in parameterised list key' => 'semicolon is valid character in parameter list',
-    ];
 }


### PR DESCRIPTION
draft-ietf-httpbis-header-structure-15 changes the behaviour for duplicate keys to overwrite previous values instead of failing, but httpwg/structured-header-tests has some rules that still expect the old behaviour and are currently skipped.

Depends on httpwg/structured-header-tests#36, httpwg/structured-header-tests#38