### PR TITLE
Update PHPUnit config for 9.3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -65,12 +65,12 @@ jobs:
       if: matrix.php-versions != '8.0'
       run: composer install --prefer-dist --no-progress --no-suggest
 
-    # PHPUnit is not yet officially compatible with PHP 8
+    # A PHPUnit dependency is not yet officially compatible with PHP 8
     - name: Install PHP 8 dependencies
       if: matrix.php-versions == '8.0'
       run: composer install --ignore-platform-reqs --prefer-dist --no-progress --no-suggest
 
-    - name: Run tests
+    - name: Run PHPUnit tests
       run: composer run-script phpunit
 
     - name: Check code style

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-json": "*",
         "httpwg/structured-field-tests": "*@dev",
         "paragonie/constant_time_encoding": "^2.3",
-        "phpunit/phpunit": "^8.5 || ^9.1",
+        "phpunit/phpunit": "^8.5 || ^9.3",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "repositories": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,13 +11,15 @@
         </testsuite>
     </testsuites>
 
-    <logging>
-        <log type="coverage-html" target="tmp/code-coverage"/>
-        <log type="coverage-clover" target="tmp/code-coverage/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage includeUncoveredFiles="true"
+              processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+
+        <report>
+            <html outputDirectory="tmp/code-coverage"/>
+            <clover outputFile="tmp/code-coverage/clover.xml"/>
+        </report>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
PHPUnit 9.3 will deprecate "whitelist" configuration element for code coverage in favour of a more descriptive term: https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-9.3.md

Since a stable release isn't yet available, this PR is still running against PHPUnit 9.2 (and 8.5 for PHP 7.2), which throws a warning during testing about the new unrecognized option names, but are still successful.

Once a stable 9.3 release is available, the version restraint in `composer.json` can be updated to `^8.5 || ^9.3` and the old configuration names removed, since coverage is only measured during the PHP 7.4 test run (PHP 7.2 / PHPUnit 8.5 don't need the old config options).