### PR TITLE
Parameters on an item within an inner list are not serialized

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -55,7 +55,7 @@ class Serializer
         $returnValue = '(';
 
         while ($item = array_shift($value)) {
-            $returnValue .= self::serializeBareItem($item[0], $item[1]);
+            $returnValue .= self::serializeItem($item[0], $item[1]);
 
             if (!empty($value)) {
                 $returnValue .= ' ';

--- a/tests/SerializeInnerListTest.php
+++ b/tests/SerializeInnerListTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace gapple\Tests\StructuredHeaders;
+
+use gapple\StructuredHeaders\Serializer;
+use PHPUnit\Framework\TestCase;
+
+class SerializeInnerListTest extends TestCase
+{
+
+    /**
+     * Items within an inner list can have parameters.
+     */
+    public function testInnerListItemWithParameters()
+    {
+        $item = [
+            [ // Inner List
+                [[1, (object) ['a' => 'b']], [2, new \stdClass()]],
+                new \stdClass(),
+            ],
+            [ // Inner List
+                [[42, new \stdClass()], [43, (object) ['c' => 'd']]],
+                new \stdClass()
+            ],
+        ];
+
+        $serialized = Serializer::serializeList($item);
+
+        $this->assertEquals('(1;a="b" 2), (42 43;c="d")', $serialized);
+    }
+}


### PR DESCRIPTION
`serializeInnerList()` was using `serializeBareItem()` instead of `serializeItem()`, resulting in any parameters being ignored during serialization.