### PR TITLE
Trigger error if ruleset has duplicate names

### DIFF
--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -64,6 +64,13 @@ abstract class RulesetTest extends TestCase
             $rule->must_fail = $rule->must_fail ?? false;
             $rule->can_fail = $rule->can_fail ?? false;
 
+            if (isset($dataset[$rule->name])) {
+                user_error(
+                    'Ruleset "' . $this->ruleset . '" contains duplicate rule name "' . $rule->name . '"',
+                    E_USER_WARNING
+                );
+            }
+
             $dataset[$rule->name] = [$rule];
         }
 


### PR DESCRIPTION
Since the test provider keys by name, duplicate names would previously cause rules to be silently skipped.

This is not an exception so that it shows in test runs but does not cause the entire ruleset to be aborted.

CI runs will have errors until httpwg/structured-field-tests#50 is merged.