### PR TITLE
Typed data

### DIFF
--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -9,6 +9,24 @@ class Dictionary implements \IteratorAggregate
      */
     protected $value = [];
 
+    public static function fromArray(array $array): Dictionary
+    {
+        $dictionary = new static();
+
+        foreach ($array as $key => $value) {
+            if (!$value instanceof TupleInterface) {
+                if (is_array($value)) {
+                    $value = InnerList::fromArray($value);
+                } else {
+                    $value = new Item($value);
+                }
+            }
+            $dictionary->{$key} = $value;
+        }
+
+        return $dictionary;
+    }
+
     public function __get($name)
     {
         return $this->value[$name] ?? null;

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace gapple\StructuredFields;
+
+class Dictionary implements \IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    protected $value = [];
+
+    public function __get($name)
+    {
+        return $this->value[$name] ?? null;
+    }
+
+    public function __set($name, $value)
+    {
+        $this->value[$name] = $value;
+    }
+
+    public function __isset($name)
+    {
+        return isset($this->value[$name]);
+    }
+
+    public function __unset($name)
+    {
+        unset($this->value[$name]);
+    }
+
+    public function getIterator(): \Iterator
+    {
+        return new \ArrayIterator($this->value);
+    }
+}

--- a/src/InnerList.php
+++ b/src/InnerList.php
@@ -19,6 +19,20 @@ class InnerList implements TupleInterface
         }
     }
 
+    public static function fromArray(array $array): InnerList
+    {
+        $list = new static([]);
+
+        foreach ($array as $item) {
+            if (!$item instanceof TupleInterface) {
+                $item = new Item($item);
+            }
+            $list->value[] = $item;
+        }
+
+        return $list;
+    }
+
     private static function validateItemType($value): void
     {
         if (is_object($value)) {

--- a/src/InnerList.php
+++ b/src/InnerList.php
@@ -13,24 +13,29 @@ class InnerList implements TupleInterface
         $this->value = $value;
 
         if (is_null($parameters)) {
-            $this->parameters = new \stdClass();
+            $this->parameters = new Parameters();
         } else {
             $this->parameters = $parameters;
         }
     }
 
+    /**
+     * Create an InnerList from an array of bare values.
+     *
+     * @param array $array
+     *   An array of bare items or TupleInterface objects.
+     * @return InnerList
+     */
     public static function fromArray(array $array): InnerList
     {
-        $list = new static([]);
-
-        foreach ($array as $item) {
+        array_walk($array, function (&$item) {
             if (!$item instanceof TupleInterface) {
                 $item = new Item($item);
             }
-            $list->value[] = $item;
-        }
+            self::validateItemType($item);
+        });
 
-        return $list;
+        return new static($array);
     }
 
     private static function validateItemType($value): void

--- a/src/InnerList.php
+++ b/src/InnerList.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace gapple\StructuredFields;
+
+class InnerList implements TupleInterface
+{
+    use TupleTrait;
+
+    public function __construct(array $value, ?object $parameters = null)
+    {
+        array_walk($value, [$this, 'validateItemType']);
+
+        $this->value = $value;
+
+        if (is_null($parameters)) {
+            $this->parameters = new \stdClass();
+        } else {
+            $this->parameters = $parameters;
+        }
+    }
+
+    private static function validateItemType($value): void
+    {
+        if (is_object($value)) {
+            if (!($value instanceof TupleInterface)) {
+                throw new \InvalidArgumentException(
+                    'Objects as list values must implement ' . TupleInterface::class
+                );
+            }
+            if ($value instanceof InnerList) {
+                throw new \InvalidArgumentException('InnerList objects cannot be nested');
+            }
+        } elseif (is_array($value)) {
+            if (count($value) != 2) {
+                throw new \InvalidArgumentException();
+            }
+        } else {
+            throw new \InvalidArgumentException();
+        }
+    }
+}

--- a/src/Item.php
+++ b/src/Item.php
@@ -11,7 +11,7 @@ class Item implements TupleInterface
         $this->value = $value;
 
         if (is_null($parameters)) {
-            $this->parameters = new \stdClass();
+            $this->parameters = new Parameters();
         } else {
             $this->parameters = $parameters;
         }

--- a/src/Item.php
+++ b/src/Item.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace gapple\StructuredFields;
+
+class Item implements TupleInterface
+{
+    use TupleTrait;
+
+    public function __construct($value, ?object $parameters = null)
+    {
+        $this->value = $value;
+
+        if (is_null($parameters)) {
+            $this->parameters = new \stdClass();
+        } else {
+            $this->parameters = $parameters;
+        }
+    }
+}

--- a/src/OuterList.php
+++ b/src/OuterList.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace gapple\StructuredFields;
+
+class OuterList implements \IteratorAggregate, \ArrayAccess
+{
+    /**
+     * The array of values.
+     *
+     * @var array
+     */
+    public $value;
+
+    public function __construct($value = [])
+    {
+        array_walk($value, [$this, 'validateItemType']);
+
+        $this->value = $value;
+    }
+
+    private static function validateItemType($value): void
+    {
+        if (is_object($value)) {
+            if (!($value instanceof TupleInterface)) {
+                throw new \InvalidArgumentException(
+                    'Objects as list values must implement ' . TupleInterface::class
+                );
+            }
+        } elseif (is_array($value)) {
+            if (count($value) != 2) {
+                throw new \InvalidArgumentException();
+            }
+        } else {
+             throw new \InvalidArgumentException();
+        }
+    }
+
+    public function getIterator(): \Iterator
+    {
+        return new \ArrayIterator($this->value);
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->value[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->value[$offset] ?? null;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        static::validateItemType($value);
+
+        if (is_null($offset)) {
+            $this->value[] = $value;
+        } else {
+            $this->value[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->value[$offset]);
+    }
+}

--- a/src/OuterList.php
+++ b/src/OuterList.php
@@ -18,7 +18,13 @@ class OuterList implements \IteratorAggregate, \ArrayAccess
         $this->value = $value;
     }
 
-    public static function fromArray($array): OuterList
+    /**
+     * Create an OuterList from an array of bare values.
+     *
+     * @param array $array
+     * @return OuterList
+     */
+    public static function fromArray(array $array): OuterList
     {
         $list = new static();
         foreach ($array as $value) {

--- a/src/OuterList.php
+++ b/src/OuterList.php
@@ -57,17 +57,18 @@ class OuterList implements \IteratorAggregate, \ArrayAccess
         return new \ArrayIterator($this->value);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->value[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->value[$offset] ?? null;
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         static::validateItemType($value);
 
@@ -78,7 +79,7 @@ class OuterList implements \IteratorAggregate, \ArrayAccess
         }
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->value[$offset]);
     }

--- a/src/OuterList.php
+++ b/src/OuterList.php
@@ -18,6 +18,23 @@ class OuterList implements \IteratorAggregate, \ArrayAccess
         $this->value = $value;
     }
 
+    public static function fromArray($array): OuterList
+    {
+        $list = new static();
+        foreach ($array as $value) {
+            if (!$value instanceof TupleInterface) {
+                if (is_array($value)) {
+                    $value = InnerList::fromArray($value);
+                } else {
+                    $value = new Item($value);
+                }
+            }
+            $list[] = $value;
+        }
+
+        return $list;
+    }
+
     private static function validateItemType($value): void
     {
         if (is_object($value)) {

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace gapple\StructuredFields;
+
+class Parameters implements \IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    protected $value = [];
+
+    public static function fromArray($array): Parameters
+    {
+        $parameters = new static();
+        $parameters->value = $array;
+
+        return $parameters;
+    }
+
+    public function __get($name)
+    {
+        return $this->value[$name] ?? null;
+    }
+
+    public function __set($name, $value)
+    {
+        $this->value[$name] = $value;
+    }
+
+    public function __isset($name)
+    {
+        return isset($this->value[$name]);
+    }
+
+    public function __unset($name)
+    {
+        unset($this->value[$name]);
+    }
+
+    public function getIterator(): \Iterator
+    {
+        return new \ArrayIterator($this->value);
+    }
+}

--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -9,7 +9,7 @@ class Parameters implements \IteratorAggregate
      */
     protected $value = [];
 
-    public static function fromArray($array): Parameters
+    public static function fromArray(array $array): Parameters
     {
         $parameters = new static();
         $parameters->value = $array;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -4,9 +4,9 @@ namespace gapple\StructuredFields;
 
 class Parser
 {
-    public static function parseDictionary(string $string): \stdClass
+    public static function parseDictionary(string $string): Dictionary
     {
-        $value = new \stdClass();
+        $value = new Dictionary();
 
         $string = ltrim($string, ' ');
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -18,7 +18,7 @@ class Parser
                 $value->{$key} = self::parseItemOrInnerList($string);
             } else {
                 // Bare boolean true value.
-                $value->{$key} = [true, self::parseParameters($string)];
+                $value->{$key} = new Item(true, self::parseParameters($string));
             }
 
             // OWS (optional whitespace) before comma.
@@ -44,9 +44,9 @@ class Parser
         return $value;
     }
 
-    public static function parseList(string $string): array
+    public static function parseList(string $string): OuterList
     {
-        $value = [];
+        $value = new OuterList();
 
         $string = ltrim($string, ' ');
 
@@ -76,7 +76,7 @@ class Parser
         return $value;
     }
 
-    private static function parseItemOrInnerList(string &$string): array
+    private static function parseItemOrInnerList(string &$string): TupleInterface
     {
         if ($string[0] === '(') {
             return self::parseInnerList($string);
@@ -85,7 +85,7 @@ class Parser
         }
     }
 
-    private static function parseInnerList(string &$string): array
+    private static function parseInnerList(string &$string): InnerList
     {
         $value = [];
 
@@ -96,10 +96,10 @@ class Parser
 
             if ($string[0] === ')') {
                 $string = substr($string, 1);
-                return [
+                return new InnerList(
                     $value,
-                    self::parseParameters($string),
-                ];
+                    self::parseParameters($string)
+                );
             }
 
             $value[] = self::doParseItem($string);
@@ -115,10 +115,10 @@ class Parser
     /**
      * @param string $string
      *
-     * @return array
+     * @return \gapple\StructuredFields\Item
      *  A [value, parameters] tuple.
      */
-    public static function parseItem(string $string): array
+    public static function parseItem(string $string): Item
     {
         $string = ltrim($string, ' ');
 
@@ -137,15 +137,15 @@ class Parser
      *
      * @param string $string
      *
-     * @return array
+     * @return \gapple\StructuredFields\Item
      *  A [value, parameters] tuple.
      */
-    private static function doParseItem(string &$string): array
+    private static function doParseItem(string &$string): Item
     {
-        return [
+        return new Item(
             self::parseBareItem($string),
             self::parseParameters($string)
-        ];
+        );
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -180,7 +180,7 @@ class Parser
 
     private static function parseParameters(string &$string): object
     {
-        $parameters = new \stdClass();
+        $parameters = new Parameters();
 
         while (!empty($string) && $string[0] === ';') {
             $string = ltrim(substr($string, 1), ' ');

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -4,9 +4,33 @@ namespace gapple\StructuredFields;
 
 class Serializer
 {
+    /**
+     * Serialize and item with optional parameters.
+     *
+     * @param $value
+     *   A bare value, or an Item object.
+     * @param object|null $parameters
+     *   An optional object containing parameter values if a bare value is provided.
+     *
+     * @return string
+     *   The serialized value.
+     */
     public static function serializeItem($value, ?object $parameters = null): string
     {
-        $output = self::serializeBareItem($value);
+        if ($value instanceof Item) {
+            if (!is_null($parameters)) {
+                throw new \InvalidArgumentException(
+                    'Parameters argument is not allowed when serializing an Item object'
+                );
+            }
+
+            $bareValue = $value[0];
+            $parameters = $value[1];
+        } else {
+            $bareValue = $value;
+        }
+
+        $output = self::serializeBareItem($bareValue);
 
         if (!empty($parameters)) {
             $output .= self::serializeParameters($parameters);
@@ -15,8 +39,12 @@ class Serializer
         return $output;
     }
 
-    public static function serializeList(array $value): string
+    public static function serializeList($value): string
     {
+        if ($value instanceof OuterList) {
+            $value = iterator_to_array($value->getIterator());
+        }
+
         $returnValue = array_map(function ($item) {
             if (is_array($item[0])) {
                 return self::serializeInnerList($item[0], $item[1]);

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -58,11 +58,18 @@ class Serializer
 
     public static function serializeDictionary(object $value): string
     {
-        $members = get_object_vars($value);
-        $keys = array_keys($members);
+        $returnValue = '';
 
-        $returnValue = array_map(function ($item, $key) {
-            $returnValue = self::serializeKey($key);
+        if (!$value instanceof Dictionary) {
+            $value = get_object_vars($value);
+        }
+
+        foreach ($value as $key => $item) {
+            if (!empty($returnValue)) {
+                $returnValue .= ', ';
+            }
+
+            $returnValue .= self::serializeKey($key);
 
             if ($item[0] === true) {
                 $returnValue .= self::serializeParameters($item[1]);
@@ -71,10 +78,9 @@ class Serializer
             } else {
                 $returnValue .= '=' . self::serializeItem($item[0], $item[1]);
             }
-            return $returnValue;
-        }, $members, $keys);
+        }
 
-        return implode(', ', $returnValue);
+        return $returnValue;
     }
 
     private static function serializeInnerList(array $value, ?object $parameters = null): string

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -187,7 +187,11 @@ class Serializer
     {
         $returnValue = '';
 
-        foreach (get_object_vars($value) as $key => $value) {
+        if (!$value instanceof Parameters) {
+            $value = get_object_vars($value);
+        }
+
+        foreach ($value as $key => $value) {
             $returnValue .= ';' . self::serializeKey($key);
 
             if ($value !== true) {

--- a/src/TupleInterface.php
+++ b/src/TupleInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace gapple\StructuredFields;
+
+/**
+ * Interface for objects that represent a [value, parameters] tuple.
+ *
+ * @see \gapple\StructuredFields\TupleTrait
+ */
+interface TupleInterface extends \ArrayAccess
+{
+}

--- a/src/TupleInterface.php
+++ b/src/TupleInterface.php
@@ -9,4 +9,6 @@ namespace gapple\StructuredFields;
  */
 interface TupleInterface extends \ArrayAccess
 {
+    public function getValue();
+    public function getParameters(): object;
 }

--- a/src/TupleTrait.php
+++ b/src/TupleTrait.php
@@ -18,9 +18,19 @@ trait TupleTrait
      */
     protected $parameters;
 
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getParameters(): object
+    {
+        return $this->parameters;
+    }
+
     public function offsetExists($offset): bool
     {
-        return $offset == 0 || $offset == 1;
+        return $offset === 0 || $offset === 1;
     }
 
     #[\ReturnTypeWillChange]
@@ -48,7 +58,7 @@ trait TupleTrait
         if ($offset == 0) {
             $this->value = null;
         } elseif ($offset == 1) {
-            $this->parameters = new \stdClass();
+            $this->parameters = new Parameters();
         }
     }
 }

--- a/src/TupleTrait.php
+++ b/src/TupleTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace gapple\StructuredFields;
+
+trait TupleTrait
+{
+    /**
+     * The tuple's value.
+     *
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * The tuple's parameters
+     *
+     * @var object
+     */
+    protected $parameters;
+
+    public function offsetExists($offset): bool
+    {
+        return $offset == 0 || $offset == 1;
+    }
+
+    public function offsetGet($offset)
+    {
+        if ($offset == 0) {
+            return $this->value;
+        } elseif ($offset == 1) {
+            return $this->parameters;
+        }
+        return null;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if ($offset == 0) {
+            $this->value = $value;
+        } elseif ($offset == 1) {
+            $this->parameters = $value;
+        }
+    }
+
+    public function offsetUnset($offset)
+    {
+        if ($offset == 0) {
+            $this->value = null;
+        } elseif ($offset == 1) {
+            $this->parameters = new \stdClass();
+        }
+    }
+}

--- a/src/TupleTrait.php
+++ b/src/TupleTrait.php
@@ -23,6 +23,7 @@ trait TupleTrait
         return $offset == 0 || $offset == 1;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($offset == 0) {
@@ -33,7 +34,7 @@ trait TupleTrait
         return null;
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($offset == 0) {
             $this->value = $value;
@@ -42,7 +43,7 @@ trait TupleTrait
         }
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if ($offset == 0) {
             $this->value = null;

--- a/tests/DictionaryTest.php
+++ b/tests/DictionaryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace gapple\Tests\StructuredFields;
+
+use gapple\StructuredFields\Dictionary;
+use PHPUnit\Framework\TestCase;
+
+class DictionaryTest extends TestCase
+{
+    public function testPropertyAccess()
+    {
+        $dictionary = new Dictionary();
+
+        $this->assertFalse(isset($dictionary->key));
+
+        $dictionary->key = ['value', (object) []];
+        $this->assertTrue(isset($dictionary->key));
+        $this->assertEquals('value', $dictionary->key[0]);
+
+        unset($dictionary->key);
+        $this->assertFalse(isset($dictionary->key));
+    }
+}

--- a/tests/DictionaryTest.php
+++ b/tests/DictionaryTest.php
@@ -3,6 +3,8 @@
 namespace gapple\Tests\StructuredFields;
 
 use gapple\StructuredFields\Dictionary;
+use gapple\StructuredFields\InnerList;
+use gapple\StructuredFields\Item;
 use PHPUnit\Framework\TestCase;
 
 class DictionaryTest extends TestCase
@@ -19,5 +21,27 @@ class DictionaryTest extends TestCase
 
         unset($dictionary->key);
         $this->assertFalse(isset($dictionary->key));
+    }
+
+    public function testFromArray()
+    {
+        $dictionary = Dictionary::fromArray([
+            'one' => true,
+            'two' => new Item(false),
+            'three' => [
+                'four',
+                new Item('five'),
+            ],
+        ]);
+
+        $expected = new Dictionary();
+        $expected->one = new Item(true);
+        $expected->two = new Item(false);
+        $expected->three = new InnerList([
+            new Item('four'),
+            new Item('five'),
+        ]);
+
+        $this->assertEquals($expected, $dictionary);
     }
 }

--- a/tests/Httpwg/HttpwgTest.php
+++ b/tests/Httpwg/HttpwgTest.php
@@ -4,6 +4,9 @@ namespace gapple\Tests\StructuredFields\Httpwg;
 
 use gapple\StructuredFields\Bytes;
 use gapple\StructuredFields\Date;
+use gapple\StructuredFields\InnerList;
+use gapple\StructuredFields\Item;
+use gapple\StructuredFields\OuterList;
 use gapple\StructuredFields\Token;
 use gapple\Tests\StructuredFields\RulesetTest;
 use ParagonIE\ConstantTime\Base32;
@@ -58,11 +61,11 @@ abstract class HttpwgTest extends RulesetTest
      * Convert the expected value of an item tuple.
      *
      * @param  array  $item
-     * @return array
+     * @return \gapple\StructuredFields\Item
      */
-    private static function convertExpectedItem(array $item): array
+    private static function convertExpectedItem(array $item): Item
     {
-        return [self::convertValue($item[0]), self::convertParameters($item[1])];
+        return new Item(self::convertValue($item[0]), self::convertParameters($item[1]));
     }
 
     /**
@@ -91,28 +94,28 @@ abstract class HttpwgTest extends RulesetTest
      * Convert the expected values of an inner list tuple.
      *
      * @param  array  $innerList
-     * @return array
+     * @return InnerList
      */
-    private static function convertInnerList(array $innerList): array
+    private static function convertInnerList(array $innerList)
     {
         $outputList = [];
 
         foreach ($innerList[0] as $value) {
-            $outputList[] = [self::convertValue($value[0]), self::convertParameters($value[1])];
+            $outputList[] = new Item(self::convertValue($value[0]), self::convertParameters($value[1]));
         }
 
-        return [$outputList, self::convertParameters($innerList[1])];
+        return new InnerList($outputList, self::convertParameters($innerList[1]));
     }
 
     /**
      * Convert the expected values of a list.
      *
      * @param  array  $list
-     * @return array
+     * @return OuterList
      */
-    private static function convertExpectedList(array $list): array
+    private static function convertExpectedList(array $list): OuterList
     {
-        $output = [];
+        $output = new OuterList();
 
         foreach ($list as $value) {
             if (is_array($value[0])) {

--- a/tests/Httpwg/HttpwgTest.php
+++ b/tests/Httpwg/HttpwgTest.php
@@ -8,6 +8,7 @@ use gapple\StructuredFields\Dictionary;
 use gapple\StructuredFields\InnerList;
 use gapple\StructuredFields\Item;
 use gapple\StructuredFields\OuterList;
+use gapple\StructuredFields\Parameters;
 use gapple\StructuredFields\Token;
 use gapple\Tests\StructuredFields\RulesetTest;
 use ParagonIE\ConstantTime\Base32;
@@ -73,11 +74,11 @@ abstract class HttpwgTest extends RulesetTest
      * Convert the expected values of a parameters map.
      *
      * @param  array  $parameters
-     * @return object
+     * @return Parameters
      */
-    private static function convertParameters(array $parameters): object
+    private static function convertParameters(array $parameters): Parameters
     {
-        $output = new \stdClass();
+        $output = new Parameters();
 
         foreach ($parameters as $value) {
             // Null byte is not supported as first character of property name.

--- a/tests/Httpwg/HttpwgTest.php
+++ b/tests/Httpwg/HttpwgTest.php
@@ -4,6 +4,7 @@ namespace gapple\Tests\StructuredFields\Httpwg;
 
 use gapple\StructuredFields\Bytes;
 use gapple\StructuredFields\Date;
+use gapple\StructuredFields\Dictionary;
 use gapple\StructuredFields\InnerList;
 use gapple\StructuredFields\Item;
 use gapple\StructuredFields\OuterList;
@@ -132,11 +133,11 @@ abstract class HttpwgTest extends RulesetTest
      * Convert the expected values of a dictionary.
      *
      * @param  array  $dictionary
-     * @return object
+     * @return Dictionary
      */
-    private static function convertExpectedDictionary(array $dictionary): object
+    private static function convertExpectedDictionary(array $dictionary): Dictionary
     {
-        $output = new \stdClass();
+        $output = new Dictionary();
 
         foreach ($dictionary as $value) {
             // Null byte is not supported as first character of property name.

--- a/tests/Httpwg/HttpwgTest.php
+++ b/tests/Httpwg/HttpwgTest.php
@@ -98,7 +98,7 @@ abstract class HttpwgTest extends RulesetTest
      * @param  array  $innerList
      * @return InnerList
      */
-    private static function convertInnerList(array $innerList)
+    private static function convertInnerList(array $innerList): InnerList
     {
         $outputList = [];
 

--- a/tests/InnerListTest.php
+++ b/tests/InnerListTest.php
@@ -3,6 +3,7 @@
 namespace gapple\Tests\StructuredFields;
 
 use gapple\StructuredFields\InnerList;
+use gapple\StructuredFields\Parameters;
 use PHPUnit\Framework\TestCase;
 
 class InnerListTest extends TestCase
@@ -11,7 +12,7 @@ class InnerListTest extends TestCase
     {
         $item = new InnerList([]);
 
-        $this->assertInstanceOf(\stdClass::class, $item[1]);
+        $this->assertInstanceOf(Parameters::class, $item[1]);
         $this->assertEmpty(get_object_vars($item[1]));
     }
 
@@ -29,7 +30,7 @@ class InnerListTest extends TestCase
         $this->assertEquals('param value', $list[1]->paramKey);
     }
 
-    public function invalidItemProvider()
+    public function invalidItemProvider(): array
     {
         $items = [];
 
@@ -56,5 +57,12 @@ class InnerListTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         new InnerList([$value]);
+    }
+
+    public function testFromArrayNestedList()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        InnerList::fromArray([new InnerList([])]);
     }
 }

--- a/tests/InnerListTest.php
+++ b/tests/InnerListTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace gapple\Tests\StructuredFields;
+
+use gapple\StructuredFields\InnerList;
+use PHPUnit\Framework\TestCase;
+
+class InnerListTest extends TestCase
+{
+    public function testDefaultParameters()
+    {
+        $item = new InnerList([]);
+
+        $this->assertInstanceOf(\stdClass::class, $item[1]);
+        $this->assertEmpty(get_object_vars($item[1]));
+    }
+
+    public function testArrayAccess()
+    {
+        $list = new InnerList(
+            [
+                ['Test Value One', (object) []],
+                ['Test Value Two', (object) []]
+            ],
+            (object) ['paramKey' => 'param value']
+        );
+
+        $this->assertEquals('Test Value One', $list[0][0][0]);
+        $this->assertEquals('param value', $list[1]->paramKey);
+    }
+
+    public function invalidItemProvider()
+    {
+        $items = [];
+
+        // Bare items are not allowed, only:
+        // - raw array tuples (e.g. `[42, {}]`)
+        // - \gapple\StructuredFields\Item
+        $items['integer'] = [42];
+        $items['string'] = ['Test'];
+        $items['stdClass'] = [new \stdClass()];
+        $items['DateTime'] = [new \DateTime()];
+
+        $items['array0'] = [[]];
+        $items['array1'] = [[1]];
+        $items['array3'] = [[1,2,3]];
+
+        return $items;
+    }
+
+    /**
+     * @dataProvider invalidItemProvider
+     */
+    public function testConstructInvalidItem($value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new InnerList([$value]);
+    }
+}

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -16,6 +16,14 @@ class ItemTest extends TestCase
         $this->assertEmpty(get_object_vars($item[1]));
     }
 
+    public function testPropertyAccess()
+    {
+        $item = new Item('Test Value', (object) ['paramKey' => 'param value']);
+
+        $this->assertEquals('Test Value', $item->getValue());
+        $this->assertEquals('param value', $item->getParameters()->paramKey);
+    }
+
     public function testArrayAccess()
     {
         $item = new Item('Test Value', (object) ['paramKey' => 'param value']);
@@ -58,6 +66,6 @@ class ItemTest extends TestCase
         unset($item[1]);
 
         $this->assertEmpty($item[0]);
-        $this->assertEquals(new \stdClass(), $item[1]);
+        $this->assertEquals(new Parameters(), $item[1]);
     }
 }

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -3,6 +3,7 @@
 namespace gapple\Tests\StructuredFields;
 
 use gapple\StructuredFields\Item;
+use gapple\StructuredFields\Parameters;
 use PHPUnit\Framework\TestCase;
 
 class ItemTest extends TestCase
@@ -11,7 +12,7 @@ class ItemTest extends TestCase
     {
         $item = new Item(true);
 
-        $this->assertInstanceOf(\stdClass::class, $item[1]);
+        $this->assertInstanceOf(Parameters::class, $item[1]);
         $this->assertEmpty(get_object_vars($item[1]));
     }
 

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace gapple\Tests\StructuredFields;
+
+use gapple\StructuredFields\Item;
+use PHPUnit\Framework\TestCase;
+
+class ItemTest extends TestCase
+{
+    public function testDefaultParameters()
+    {
+        $item = new Item(true);
+
+        $this->assertInstanceOf(\stdClass::class, $item[1]);
+        $this->assertEmpty(get_object_vars($item[1]));
+    }
+
+    public function testArrayAccess()
+    {
+        $item = new Item('Test Value', (object) ['paramKey' => 'param value']);
+
+        $this->assertEquals('Test Value', $item[0]);
+        $this->assertEquals('param value', $item[1]->paramKey);
+    }
+
+    public function testArraySet()
+    {
+        $item = new Item('Test Value', (object) ['paramKey' => 'param value']);
+
+        $item[0] = 'Modified Value';
+        $item[1] = (object) ['paramKey' => 'Modified param value'];
+        $this->assertEquals('Modified Value', $item[0]);
+        $this->assertEquals('Modified param value', $item[1]->paramKey);
+    }
+
+    public function testArrayIndexIsset()
+    {
+        $item = new Item(true);
+
+        $this->assertTrue(isset($item[0]));
+        $this->assertTrue(isset($item[1]));
+        $this->assertFalse(isset($item[2]));
+    }
+
+    public function testArrayOutOfBounds()
+    {
+        $item = new Item(true);
+
+        $this->assertEmpty($item[2]);
+    }
+
+    public function testArrayUnset()
+    {
+        $item = new Item('Test Value', (object) ['paramKey' => 'param value']);
+
+        unset($item[0]);
+        unset($item[1]);
+
+        $this->assertEmpty($item[0]);
+        $this->assertEquals(new \stdClass(), $item[1]);
+    }
+}

--- a/tests/OuterListTest.php
+++ b/tests/OuterListTest.php
@@ -2,6 +2,8 @@
 
 namespace gapple\Tests\StructuredFields;
 
+use gapple\StructuredFields\InnerList;
+use gapple\StructuredFields\Item;
 use gapple\StructuredFields\OuterList;
 use PHPUnit\Framework\TestCase;
 
@@ -121,5 +123,28 @@ class OuterListTest extends TestCase
 
         $list = new OuterList();
         $list[] = $value;
+    }
+
+    public function testFromArray()
+    {
+        $dictionary = OuterList::fromArray([
+            true,
+            new Item(false),
+            [
+                'four',
+                new Item('five'),
+            ],
+        ]);
+
+        $expected = new OuterList([
+            new Item(true),
+            new Item(false),
+            new InnerList([
+                new Item('four'),
+                new Item('five'),
+            ]),
+        ]);
+
+        $this->assertEquals($expected, $dictionary);
     }
 }

--- a/tests/OuterListTest.php
+++ b/tests/OuterListTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace gapple\Tests\StructuredFields;
+
+use gapple\StructuredFields\OuterList;
+use PHPUnit\Framework\TestCase;
+
+class OuterListTest extends TestCase
+{
+    public function testArrayAccess()
+    {
+        $item = new OuterList([
+            ['Test Value One', (object) []],
+            ['Test Value Two', (object) []],
+        ]);
+
+        $this->assertEquals('Test Value One', $item[0][0]);
+    }
+
+    public function testArrayIsset()
+    {
+        $item = new OuterList([
+            ['Test Value One', (object) []],
+            ['Test Value Two', (object) []],
+        ]);
+
+        $this->assertTrue(isset($item[0]));
+        $this->assertTrue(isset($item[1]));
+        $this->assertFalse(isset($item[2]));
+    }
+
+    public function testArrayAppend()
+    {
+        $item = new OuterList([
+            ['Test Value One', (object) []],
+            ['Test Value Two', (object) []],
+        ]);
+        $item[] = ['Test Value Three', (object) []];
+
+        $this->assertEquals('Test Value Three', $item[2][0]);
+    }
+
+    public function testArrayOverwrite()
+    {
+        $item = new OuterList([
+            ['Test Value One', (object) []],
+            ['Test Value Two', (object) []],
+        ]);
+        $item[1] = ['Test Value Three', (object) []];
+
+        $this->assertEquals('Test Value One', $item[0][0]);
+        $this->assertEquals('Test Value Three', $item[1][0]);
+    }
+
+    public function testArrayUnset()
+    {
+        $item = new OuterList([
+            ['Test Value One', (object) []],
+            ['Test Value Two', (object) []],
+        ]);
+        unset($item[1]);
+
+        $this->assertEquals('Test Value One', $item[0][0]);
+        $this->assertEmpty($item[1]);
+    }
+
+    public function testIteration()
+    {
+        $listValues = [
+            ['Test Value One', (object) []],
+            ['Test Value Two', (object) []],
+        ];
+        $list = new OuterList($listValues);
+
+        $this->assertIsIterable($list);
+
+        $iterated = 0;
+        foreach ($list as $key => $value) {
+            $this->assertEquals($listValues[$key], $value);
+            $iterated++;
+        }
+        $this->assertEquals(count($listValues), $iterated);
+    }
+
+    public function invalidItemProvider()
+    {
+        $items = [];
+
+        // Bare items are not allowed, only:
+        // - raw array tuples (e.g. `[42, {}]`)
+        // - \gapple\StructuredFields\Item
+        // - \gapple\StructuredFields\InnerList
+        $items['integer'] = [42];
+        $items['string'] = ['Test'];
+        $items['stdClass'] = [new \stdClass()];
+        $items['DateTime'] = [new \DateTime()];
+
+        $items['array0'] = [[]];
+        $items['array1'] = [[1]];
+        $items['array3'] = [[1,2,3]];
+
+        return $items;
+    }
+
+    /**
+     * @dataProvider invalidItemProvider
+     */
+    public function testConstructInvalidItem($value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new OuterList([$value]);
+    }
+
+    /**
+     * @dataProvider invalidItemProvider
+     */
+    public function testAppendInvalidItem($value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $list = new OuterList();
+        $list[] = $value;
+    }
+}

--- a/tests/ParametersTest.php
+++ b/tests/ParametersTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace gapple\Tests\StructuredFields;
+
+use gapple\StructuredFields\Dictionary;
+use gapple\StructuredFields\Parameters;
+use PhpParser\Node\Param;
+use PHPUnit\Framework\TestCase;
+
+class ParametersTest extends TestCase
+{
+    public function testPropertyAccess()
+    {
+        $parameters = new Parameters();
+
+        $this->assertFalse(isset($parameters->key));
+
+        $parameters->key = 'value';
+        $this->assertTrue(isset($parameters->key));
+        $this->assertEquals('value', $parameters->key);
+
+        unset($parameters->key);
+        $this->assertFalse(isset($parameters->key));
+    }
+
+    public function testFromArray()
+    {
+        $parameters = Parameters::fromArray([
+            'one' => true,
+            'two' => 'false',
+        ]);
+
+        $this->assertSame(true, $parameters->one);
+        $this->assertSame('false', $parameters->two);
+    }
+}

--- a/tests/ParseListTest.php
+++ b/tests/ParseListTest.php
@@ -4,6 +4,7 @@ namespace gapple\Tests\StructuredFields;
 
 use gapple\StructuredFields\Item;
 use gapple\StructuredFields\OuterList;
+use gapple\StructuredFields\Parameters;
 use gapple\StructuredFields\Parser;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ class ParseListTest extends TestCase
             'expected' => new OuterList([
                 new Item('one'),
                 new Item(1),
-                new Item(42, (object) ['towel' => true, 'panic' => false]),
+                new Item(42, Parameters::fromArray(['towel' => true, 'panic' => false])),
                 new Item('two'),
             ])
         ];
@@ -26,8 +27,8 @@ class ParseListTest extends TestCase
         $dataset[] = [
             'raw' => '"\"Not\\\A;Brand";v="99", "Chromium";v="86"',
             'expected' => new OuterList([
-                new Item('"Not\\A;Brand', (object) ['v' => "99"]),
-                new Item('Chromium', (object) ['v' => "86"]),
+                new Item('"Not\\A;Brand', Parameters::fromArray(['v' => "99"])),
+                new Item('Chromium', Parameters::fromArray(['v' => "86"])),
             ]),
         ];
 

--- a/tests/ParseListTest.php
+++ b/tests/ParseListTest.php
@@ -2,6 +2,8 @@
 
 namespace gapple\Tests\StructuredFields;
 
+use gapple\StructuredFields\Item;
+use gapple\StructuredFields\OuterList;
 use gapple\StructuredFields\Parser;
 use PHPUnit\Framework\TestCase;
 
@@ -13,20 +15,20 @@ class ParseListTest extends TestCase
 
         $dataset[] = [
             'raw' => '"one", 1, 42;towel;panic=?0, "two"',
-            'expected' => [
-                ['one', (object) []],
-                [1, (object) []],
-                [42, (object) ['towel' => true, 'panic' => false]],
-                ['two', (object) []],
-            ]
+            'expected' => new OuterList([
+                new Item('one'),
+                new Item(1),
+                new Item(42, (object) ['towel' => true, 'panic' => false]),
+                new Item('two'),
+            ])
         ];
 
         $dataset[] = [
             'raw' => '"\"Not\\\A;Brand";v="99", "Chromium";v="86"',
-            'expected' => [
-                ['"Not\\A;Brand', (object) ['v' => "99"]],
-                ['Chromium', (object) ['v' => "86"]],
-            ],
+            'expected' => new OuterList([
+                new Item('"Not\\A;Brand', (object) ['v' => "99"]),
+                new Item('Chromium', (object) ['v' => "86"]),
+            ]),
         ];
 
         return $dataset;

--- a/tests/RulesetTest.php
+++ b/tests/RulesetTest.php
@@ -2,14 +2,10 @@
 
 namespace gapple\Tests\StructuredFields;
 
-use gapple\StructuredFields\Bytes;
-use gapple\StructuredFields\Date;
 use gapple\StructuredFields\ParseException;
 use gapple\StructuredFields\Parser;
 use gapple\StructuredFields\SerializeException;
 use gapple\StructuredFields\Serializer;
-use gapple\StructuredFields\Token;
-use ParagonIE\ConstantTime\Base32;
 use PHPUnit\Framework\TestCase;
 
 abstract class RulesetTest extends TestCase
@@ -118,11 +114,7 @@ abstract class RulesetTest extends TestCase
         }
 
         try {
-            if ($record->header_type == 'item') {
-                $serializedValue = Serializer::serializeItem($record->expected[0], $record->expected[1]);
-            } else {
-                $serializedValue = Serializer::{'serialize' . ucfirst($record->header_type)}($record->expected);
-            }
+            $serializedValue = Serializer::{'serialize' . ucfirst($record->header_type)}($record->expected);
 
             if ($record->must_fail) {
                 $this->fail($this->ruleset . ' "' . $record->name . '" must fail serializing');

--- a/tests/SerializeDictionaryTest.php
+++ b/tests/SerializeDictionaryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace gapple\Tests\StructuredFields;
+
+use gapple\StructuredFields\Item;
+use gapple\StructuredFields\SerializeException;
+use gapple\StructuredFields\Serializer;
+use PHPUnit\Framework\TestCase;
+
+class SerializeDictionaryTest extends TestCase
+{
+    public function testUntyped()
+    {
+        $dictionary = (object) [
+            'one' => [true, (object) []],
+            'two' => ['three', (object) ['param' => 'value']],
+        ];
+
+        $this->assertEquals(
+            'one, two="three";param="value"',
+            Serializer::serializeDictionary($dictionary)
+        );
+    }
+}

--- a/tests/SerializeItemTest.php
+++ b/tests/SerializeItemTest.php
@@ -2,16 +2,44 @@
 
 namespace gapple\Tests\StructuredFields;
 
+use gapple\StructuredFields\Item;
 use gapple\StructuredFields\SerializeException;
 use gapple\StructuredFields\Serializer;
 use PHPUnit\Framework\TestCase;
 
 class SerializeItemTest extends TestCase
 {
-    public function testUnkownType()
+    public function testUnknownType()
     {
         $this->expectException(SerializeException::class);
 
         Serializer::serializeItem(new \stdClass());
+    }
+
+    public function testNullValueItem()
+    {
+        $this->expectException(SerializeException::class);
+        $this->expectExceptionMessage('Unrecognized type');
+
+        Serializer::serializeItem(new Item(null));
+    }
+
+    public function testNoParameters()
+    {
+        $item = new Item(true);
+
+        $result = Serializer::serializeItem($item);
+
+        $this->assertEquals('?1', $result);
+    }
+
+    public function testItemObjectWithParameters()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $parameters = new \stdClass();
+        $item = new Item(true, $parameters);
+
+        Serializer::serializeItem($item, $parameters);
     }
 }

--- a/tests/SerializeListTest.php
+++ b/tests/SerializeListTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace gapple\Tests\StructuredFields;
+
+use gapple\StructuredFields\OuterList;
+use gapple\StructuredFields\Parameters;
+use gapple\StructuredFields\Serializer;
+use PHPUnit\Framework\TestCase;
+
+class SerializeListTest extends TestCase
+{
+    /**
+     * A list with bare tuples.
+     */
+    public function testUntypedList()
+    {
+        $itemParam = new \stdClass();
+        $itemParam->item_param = 32;
+
+        $value = new OuterList([
+            ['value1', $itemParam],
+            ['value2', (object) []],
+            [
+                [
+                    ['listvalue1', (object) []],
+                    ['listvalue2', (object) []],
+                ],
+                Parameters::fromArray(['list-param' => 'value']),
+            ],
+        ]);
+
+        $serialized = Serializer::serializeList($value);
+
+        $this->assertEquals(
+            '"value1";item_param=32, "value2", ("listvalue1" "listvalue2");list-param="value"',
+            $serialized
+        );
+    }
+}


### PR DESCRIPTION
New classes make constructing a value to pass to `Serializer` and working with data from `Parser` easier.  
Tuple types (`Item` and `InnerList`) are still accessible by array indexes to be backwards compatible with older code (`$item->value === $item[0]`, `$item->parameters === $item[1]`)
- [x] `Item`
- [x] `OuterList`
- [x] `InnerList`
- [x] `Dictionary`
- [x] `Parameters`
``` 
Serializer::serializeItem(new Item(true));
// ?1
Serializer::serializeItem(new Item('towel', (object) ['panic' => false']));
// "towel";panic=?0
```
----
Resolves #19 