### PR TITLE
Fail if bytesequence base64 has padding characters before end of string

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -357,7 +357,7 @@ class Parser
         $startPosition = $input->position();
         $input->consumeChar(':');
         try {
-            $bytes = $input->consumeRegex('/^([a-z0-9+\/=]*)/i');
+            $bytes = $input->consumeRegex('/^([a-z0-9+\/]*=*)(?=:)/i');
             $input->consumeChar(':');
             return new Bytes(base64_decode($bytes));
         } catch (\RuntimeException) {


### PR DESCRIPTION
httpwg/structured-field-tests#94